### PR TITLE
fix(chart): #MBA-118 do not more open chart when user have neither assign nor receive right

### DIFF
--- a/src/main/resources/public/ts/directives/container-header/container-header.directive.ts
+++ b/src/main/resources/public/ts/directives/container-header/container-header.directive.ts
@@ -13,6 +13,7 @@ interface IViewModel {
 
 interface IDirectiveProperties {
     containerHeader?: ContainerHeader;
+    showChartLightbox?: boolean;
     openChartLightbox(): void;
 }
 
@@ -46,7 +47,8 @@ function directive(): IDirective {
         templateUrl: `${RootsConst.directive}/container-header/container-header.html`,
         scope: {
             openChartLightbox: '&',
-            containerHeader: '=?'
+            containerHeader: '=?',
+            showChartLightbox: '=?'
         },
         controllerAs: 'vm',
         bindToController: true,

--- a/src/main/resources/public/ts/directives/container-header/container-header.html
+++ b/src/main/resources/public/ts/directives/container-header/container-header.html
@@ -8,7 +8,8 @@
                 ng-click="vm.buttonClick(button)">
             <i ng-if="!!button.icon" ng-class="button.icon"></i>&nbsp;<span>[[vm.lang.translate(button.label)]]</span>
         </button>
-        <button class="minibadge-button-title-settings desktop-disabled minibadge-mobile-padding-x"
+        <button ng-if="vm.showChartLightbox"
+                class="minibadge-button-title-settings desktop-disabled minibadge-mobile-padding-x"
                 ng-click="vm.openChartLightbox()">
             <i class="settings"></i>&nbsp;<i18n>minibadge.settings</i18n>
         </button>

--- a/src/main/resources/view-src/minibadge.html
+++ b/src/main/resources/view-src/minibadge.html
@@ -22,7 +22,8 @@
                  alt="" src="/minibadge/public/img/uni-minibadge.svg">&nbsp;
             <i18n>minibadge.title</i18n>
         </h1>
-        <button class="minibadge-button-title-settings mobile-disabled minibadge-mobile-padding-x absolute-position no-margin-bottom"
+        <button ng-if="vm.isAllowedToUseMinibadge"
+                class="minibadge-button-title-settings mobile-disabled minibadge-mobile-padding-x absolute-position no-margin-bottom"
                 ng-click="vm.openChartLightbox()">
             <i class="settings"></i>&nbsp;<i18n>minibadge.settings</i18n>
         </button>
@@ -30,14 +31,17 @@
     <minibadge-navbar navbar-view-selected="vm.navbarViewSelected"></minibadge-navbar>
     <div class="minibadge-container flex-row f-column">
         <minibadge-container-header container-header="vm.containerHeader"
-                                    open-chart-lightbox="vm.openChartLightbox()"></minibadge-container-header>
+                                    open-chart-lightbox="vm.openChartLightbox()"
+                                    show-chart-lightbox="vm.isAllowedToUseMinibadge"></minibadge-container-header>
         <container template="main"></container>
     </div>
-    <minibadge-chart is-lightbox-opened="vm.isChartLightboxOpened"
-                     is-chart-accepted="vm.isChartAccepted"
-                     is-minibadge-accepted="vm.isMinibadgeAccepted"
-                     chart-validate="vm.chartValidate()"
-                     on-close="vm.resetChartValues()"></minibadge-chart>
+    <minibadge-chart
+            ng-if="vm.isAllowedToUseMinibadge"
+            is-lightbox-opened="vm.isChartLightboxOpened"
+            is-chart-accepted="vm.isChartAccepted"
+            is-minibadge-accepted="vm.isMinibadgeAccepted"
+            chart-validate="vm.chartValidate()"
+            on-close="vm.resetChartValues()"></minibadge-chart>
 </portal>
 </body>
 


### PR DESCRIPTION
## Describe your changes
Désormais quand l'utilisateur n'a ni le droit d'assignation ou de réception de badge, la chart ne lui est pas affichée.

## Checklist tests
- Utiliser un utilisateur n'ayant pas la chart accepté, mais ayant au moins un des 2 droits assigner ou recevoir.
- Vérifier qu'au rechargement de la page, la chart s'affiche
- Lui enlever les 2 droits précédents
- Vérifier que la chart ne s'affiche plus.

## Issue ticket number and link
[Jira - MBA-118](https://jira.support-ent.fr/browse/MBA-118)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
