### PR TITLE
fix(rights): #MBA-119 access to badge type detail, even if we are in view mode is now possible

### DIFF
--- a/src/main/resources/public/template/badge-types.html
+++ b/src/main/resources/public/template/badge-types.html
@@ -6,8 +6,7 @@
                              on-body-click="vm.redirectBadgeType(badgeType)"
                              on-footer-click="vm.onOpenLightbox(badgeType)"
                              click-path="badgeType.getDetailPath()"
-                             footer="vm.CARD_FOOTER.AWARD_BADGE"
-                             is-disabled="!vm.isMinibadgeAccepted"
+                             footer="vm.getCardFooter"
                              body-icon="'icon-info-circle minibadge-icon-right'"
         >
         </minibadge-card-type>

--- a/src/main/resources/public/ts/controllers/badge-type.controller.ts
+++ b/src/main/resources/public/ts/controllers/badge-type.controller.ts
@@ -1,4 +1,4 @@
-import {Behaviours, idiom as lang, ng, notify} from 'entcore';
+import {Behaviours, idiom as lang, model, ng, notify} from 'entcore';
 
 import {IBadgeTypeService} from "../services";
 import {BadgeType} from "../models/badge-type.model";
@@ -13,6 +13,7 @@ import {ContainerHeader, IContainerHeaderResponse} from "../models/container-hea
 import {ActionOption, IActionOptionResponse} from "../models/action-option.model";
 import {toLocaleString} from "../utils/number.utils";
 import {translate} from "../utils/string.utils";
+import {rights} from "../core/constants/rights.const";
 
 
 interface ViewModel {
@@ -90,7 +91,7 @@ class Controller implements ng.IController, ViewModel {
     displayItemImg = (user: User): string => `/userbook/avatar/${user.id}?thumbnail=48x48`;
 
     getBadgeTypeAssigners = async (): Promise<void> => {
-        if (this.badgeType)
+        if (this.badgeType && this.$scope.setting.userPermissions.canReceive())
             this.badgeTypeService.getBadgeTypeAssigners(this.badgeType, this.assignersPayload)
                 .then((data: User[]) => {
                     if (data) {

--- a/src/main/resources/public/ts/controllers/badge-types.controller.ts
+++ b/src/main/resources/public/ts/controllers/badge-types.controller.ts
@@ -1,4 +1,4 @@
-import {Behaviours, ng, notify} from 'entcore';
+import {Behaviours, model, ng, notify} from 'entcore';
 
 import {IBadgeTypeService} from "../services";
 import {BadgeType, IBadgeTypesPayload} from "../models/badge-type.model";
@@ -8,6 +8,7 @@ import {ILocationService, IScope} from "angular";
 import {Setting} from "../models/setting.model";
 import {CARD_FOOTER} from "../core/enum/card-footers.enum";
 import {unaccent} from "../utils/string.utils";
+import {rights} from "../core/constants/rights.const";
 
 
 interface ViewModel {
@@ -21,8 +22,8 @@ interface ViewModel {
 
     onOpenLightbox(badgeType: BadgeType): void;
 
-    CARD_FOOTER: typeof CARD_FOOTER;
     badgeTypes: BadgeType[];
+    getCardFooter: string;
     searchQuery: string;
 }
 
@@ -33,22 +34,18 @@ interface IMinibadgeScope extends IScope {
 
 class Controller implements ng.IController, ViewModel {
     private payload: IBadgeTypesPayload;
-
-    CARD_FOOTER: typeof CARD_FOOTER;
     badgeTypes: BadgeType[];
     searchQuery: string;
-    isMinibadgeAccepted: boolean;
+    getCardFooter: string;
 
     constructor(private $scope: IMinibadgeScope,
                 private $location: ILocationService,
                 private badgeTypeService: IBadgeTypeService) {
         this.$scope.vm = this;
-        this.CARD_FOOTER = CARD_FOOTER;
         this.payload = {
             offset: 0,
         };
-        this.isMinibadgeAccepted = !!this.$scope.setting.userPermissions.acceptAssign
-            || !!this.$scope.setting.userPermissions.acceptReceive;
+        this.getCardFooter = this.$scope.setting.userPermissions.canAssign() ? CARD_FOOTER.AWARD_BADGE : null;
     }
 
     $onInit() {

--- a/src/main/resources/public/ts/directives/card/card-type.html
+++ b/src/main/resources/public/ts/directives/card/card-type.html
@@ -16,7 +16,7 @@
              class="minibadge-card-title flex-row justify-center align-center">[[vm.badgeType.label]]
         </div>
     </container-body>
-    <container-footer>
+    <container-footer ng-if="!!vm.footer && !vm.isDisabled">
         <award-badge-footer ng-if="vm.CARD_FOOTER.AWARD_BADGE === vm.footer && !vm.isDisabled"
                             on-click="vm.onFooterClick(vm.badgeType)"
                             badge-type="vm.badgeType"></award-badge-footer>

--- a/src/main/resources/public/ts/models/chart.model.ts
+++ b/src/main/resources/public/ts/models/chart.model.ts
@@ -1,4 +1,6 @@
 import {MinibadgeModel} from "./model";
+import {model} from "entcore";
+import {rights} from "../core/constants/rights.const";
 
 export interface IChartResponse {
     acceptChart?: string;
@@ -22,6 +24,9 @@ export class Chart extends MinibadgeModel<Chart> {
         this.acceptReceive = data.acceptReceive;
         return this;
     }
+
+    canAssign = (): boolean => model.me.hasWorkflow(rights.workflow.assign) && !!this.acceptAssign;
+    canReceive = (): boolean => model.me.hasWorkflow(rights.workflow.receive) && !!this.acceptReceive;
 
     toModel(model: any): Chart {
         return new Chart(model)


### PR DESCRIPTION
## Describe your changes
Il est désormais possible d'accéder au détail d'un type de badge, malgré le fait qu'on ai juste le droit view

## Checklist tests
- Se connecter à un utilisateur n'ayant que le droit minibadge.view
- Aller sur la collection des types de badge.
- Cliquer sur un badge pour accéder à son détail.

## Issue ticket number and link
[Jira - MBA-119](https://jira.support-ent.fr/browse/MBA-119)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
