### PR TITLE
fix(statistics): #MBA-120 retrieve most badge types refused no longer takes those have never been refused once

### DIFF
--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultStatisticService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultStatisticService.java
@@ -190,7 +190,7 @@ public class DefaultStatisticService implements StatisticService {
                         " INNER JOIN %s bas on ba.id = bas.badge_assigned_id " +
                         " WHERE is_structure_receiver IS TRUE %s " +
                         " GROUP BY b.badge_type_id) b on bt.id = b.badge_type_id WHERE %s " +
-                        " GROUP BY bt.id, b.count_refused  ORDER BY count_refused DESC LIMIT %s",
+                        " GROUP BY bt.id, b.count_refused HAVING count_refused > 0 ORDER BY count_refused DESC LIMIT %s",
                 DefaultBadgeTypeService.BADGE_TYPE_TABLE,
                 DefaultBadgeService.BADGE_DISABLED_TABLE,
                 DefaultBadgeAssignedService.BADGE_ASSIGNED_VALID_TABLE,


### PR DESCRIPTION
## Describe your changes
Admettons qu'en config, on dit qu'on ne récupère que les 3 badges les plus refusés:
Désormais, s'il n'y a que 2 badges refusés sur l'établissement, ne récupère que ces 2 badges (et n'en prend pas un au hasard, avec un compteur à 0, pour combler cette limite de 3 badges).

## Checklist tests
- Aller sur un etab où moins de 3 badges ont étés refusés
- Sur la page des statistiques, constater qu'il y a moins de 3 "badges les plus refusés" récupéré.

## Issue ticket number and link
[Jira - MBA-120](https://jira.support-ent.fr/browse/MBA-120)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
