### PR TITLE
fix(chart): #MBA-130 force opening chart at first connection only

### DIFF
--- a/src/main/java/fr/openent/minibadge/core/constants/Field.java
+++ b/src/main/java/fr/openent/minibadge/core/constants/Field.java
@@ -74,6 +74,8 @@ public class Field {
     public static final String ACCEPTCHART = "acceptChart";
     public static final String ACCEPTASSIGN = "acceptAssign";
     public static final String ACCEPTRECEIVE = "acceptReceive";
+    public static final String READCHART = "readChart";
+    public static final String VALIDATECHART = "validateChart";
     public static final String PERMISSIONS = "permissions";
 
     //USER

--- a/src/main/java/fr/openent/minibadge/model/Chart.java
+++ b/src/main/java/fr/openent/minibadge/model/Chart.java
@@ -8,6 +8,8 @@ public class Chart implements Model<Chart> {
     private String acceptChart;
     private String acceptAssign;
     private String acceptReceive;
+    private String readChart;
+    private String validateChart;
 
     public Chart() {
     }
@@ -23,6 +25,8 @@ public class Chart implements Model<Chart> {
         this.acceptChart = permissions.getString(Field.ACCEPTCHART, chart.getString(Field.ACCEPTCHART)) ;
         this.acceptAssign = permissions.getString(Field.ACCEPTASSIGN, chart.getString(Field.ACCEPTASSIGN)) ;
         this.acceptReceive = permissions.getString(Field.ACCEPTRECEIVE, chart.getString(Field.ACCEPTRECEIVE));
+        this.readChart = permissions.getString(Field.READCHART, chart.getString(Field.READCHART));
+        this.validateChart = permissions.getString(Field.VALIDATECHART, chart.getString(Field.VALIDATECHART));
         return this;
     }
 
@@ -31,7 +35,9 @@ public class Chart implements Model<Chart> {
         return new JsonObject()
                 .put(Field.ACCEPTCHART, this.acceptChart)
                 .put(Field.ACCEPTASSIGN, this.acceptAssign)
-                .put(Field.ACCEPTRECEIVE, this.acceptReceive);
+                .put(Field.ACCEPTRECEIVE, this.acceptReceive)
+                .put(Field.READCHART, this.readChart)
+                .put(Field.VALIDATECHART, this.validateChart);
     }
 
     @Override
@@ -49,5 +55,8 @@ public class Chart implements Model<Chart> {
 
     public String acceptReceive() {
         return acceptReceive;
+    }
+    public String validateChart() {
+        return validateChart;
     }
 }

--- a/src/main/java/fr/openent/minibadge/security/UsersAssignRight.java
+++ b/src/main/java/fr/openent/minibadge/security/UsersAssignRight.java
@@ -63,7 +63,7 @@ public class UsersAssignRight implements ResourcesProvider {
                         return getUserPermissions(cachedPermissionsFuture.result(), userInfos, request);
                     })
                     .compose(permissions -> {
-                        if (permissions.acceptChart() == null)
+                        if (permissions.acceptChart() == null || permissions.acceptAssign() == null)
                             return Future.failedFuture(
                                     String.format("[Minibadge@%s::authorize] User is not allowed to assign.",
                                             this.getClass().getSimpleName()));
@@ -76,7 +76,7 @@ public class UsersAssignRight implements ResourcesProvider {
                                 .isAuthorizedToAssign(new User(userInfos), receivers, typeSetting);
                         boolean canUsersReceive = receivers.stream()
                                 .allMatch(user ->
-                                        user.permissions().acceptChart() == null
+                                        user.permissions().validateChart() == null
                                                 || user.permissions().acceptReceive() != null);
                         handler.handle(ownerIds.size() == receivers.size() && isAuthorizedToAssign && canUsersReceive);
                     })

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultUserService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultUserService.java
@@ -82,7 +82,7 @@ public class DefaultUserService implements UserService {
     private List<User> mapToAuthorizedAssignUsers(UserInfos user, JsonArray users) {
         return new User().toList(users)
                 .stream().filter(queriedUser ->
-                        queriedUser.permissions().acceptChart() == null
+                        queriedUser.permissions().validateChart() == null
                                 || queriedUser.permissions().acceptReceive() != null
                                 // We currently consider that all types have default setting
                                 && SettingHelper.isAuthorizedToAssign(new User(user), queriedUser,

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -14,7 +14,7 @@ import {safeApply} from "../utils/safe-apply.utils";
 interface ViewModel {
     openChartLightbox(): void;
 
-    chartValidate(): Promise<void>;
+    chartValidate(isValidate?: boolean): Promise<void>;
 
     resetChartValues(): void;
 
@@ -106,13 +106,14 @@ class Controller implements ng.IController, ViewModel {
             .then(async () => {
                 this.$scope.setting.userPermissions = await this.chartService.getChart();
                 Behaviours.applicationsBehaviours[MINIBADGE_APP].chartEventsService
-                    .validateChart(this.$scope.setting.userPermissions)
+                    .validateChart(this.$scope.setting.userPermissions);
                 await this.resetChartValues();
             })
             .catch(() => notify.error('minibadge.error.chart.validate'));
     }
 
     resetChartValues = async (): Promise<void> => {
+        await this.chartService.viewChart();
         this.$scope.vm.isChartAccepted = !!this.$scope.setting.userPermissions.acceptChart;
         this.$scope.vm.isMinibadgeAccepted = !!this.$scope.setting.userPermissions.acceptAssign
             || !!this.$scope.setting.userPermissions.acceptReceive;
@@ -134,6 +135,7 @@ class Controller implements ng.IController, ViewModel {
                 this.isAllowedToUseMinibadge = data[2] || data[3];
 
                 this.isChartLightboxOpened = this.isAllowedToUseMinibadge &&
+                    !this.$scope.setting.userPermissions.readChart &&
                     !this.$scope.setting.userPermissions.acceptChart;
                 this.isChartAccepted = !!this.$scope.setting.userPermissions.acceptChart;
                 this.isMinibadgeAccepted = !!this.$scope.setting.userPermissions.acceptChart

--- a/src/main/resources/public/ts/models/chart.model.ts
+++ b/src/main/resources/public/ts/models/chart.model.ts
@@ -6,12 +6,16 @@ export interface IChartResponse {
     acceptChart?: string;
     acceptAssign?: string;
     acceptReceive?: string;
+    readChart?: string;
+    validateChart?: string;
 }
 
 export class Chart extends MinibadgeModel<Chart> {
     acceptChart?: string;
     acceptAssign?: string;
     acceptReceive?: string;
+    readChart?: string;
+    validateChart?: string;
 
     constructor(data?: IChartResponse) {
         super();
@@ -22,6 +26,8 @@ export class Chart extends MinibadgeModel<Chart> {
         this.acceptChart = data.acceptChart;
         this.acceptAssign = data.acceptAssign;
         this.acceptReceive = data.acceptReceive;
+        this.readChart = data.readChart;
+        this.validateChart = data.validateChart;
         return this;
     }
 


### PR DESCRIPTION
## Describe your changes
Désormais, l'ouverture de la chart ne se fait  automatiquement que lors de la première connexion au module.
Enfin, si l'utilisateur se contente de fermer le module (avec la croix), on pourra continuer de lui assigner des badges.
A contrario, si on valide la chart (malgré sa non acceptation), il ne sera plus possible de lui assigner de badge.

## Checklist tests
- Se connecter avec un nouvel utilisateur A
- Cliquer sur la croix de la charte
- Se connecter avec un autre utilisateur B
- Assigner un badge à l'utilisateur A -> c'est possible
- Se reconnecter à l'utilisateur A
- La charte ne s'ouvre pas !
- Ouvrir la charte avec le bouton réglage, valider la charte sans l'accepter
- Se reconnecter à l'utilisateur B
-  Essayer d'assigner un badge à l'utilisateur A -> ce n'est plus possible !
- Se reconnecter avec A
- Ouvrir la charte, accepter la charte, accepter de recevoir des badges
- Il est de nouveau possible d'assigner un badge à A avec B !

## Issue ticket number and link
[Jira - MBA-130](https://jira.support-ent.fr/browse/MBA-130)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
