### PR TITLE
fix(assign): #MBA-137 adapt insert / returning insertion, to minimize request and avoid sql  synchronisation problem

### DIFF
--- a/.github/workflows/dev-check-repository.yml
+++ b/.github/workflows/dev-check-repository.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run npm install
         run: npm install
-      - name: Run build node with Gulp
+      - name: Run build node with Gulp minibadge
         run: node_modules/gulp/bin/gulp.js build
       - name: Run test
         run: npm test

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     testCompile "org.entcore:tests:$entCoreVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "org.powermock:powermock-core:$powerMockVersion"
+    testCompile "org.reflections:reflections:$reflectionsVersion"
     testCompile 'io.gatling.highcharts:gatling-charts-highcharts:2.2.2'
     testCompile "io.vertx:vertx-core:$vertxVersion"
     testCompile "io.vertx:testtools:$toolsVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,6 @@ toolsVersion=2.0.0-final
 junitVersion=5.1.0
 vertxCronTimer=2.0.0
 powerMockVersion=2.0.2
+reflectionsVersion=0.10.2
 mockitoVersion=2.+
 entCoreVersion=4.10.2

--- a/src/main/java/fr/openent/minibadge/helper/ModelHelper.java
+++ b/src/main/java/fr/openent/minibadge/helper/ModelHelper.java
@@ -1,0 +1,135 @@
+package fr.openent.minibadge.helper;
+
+import fr.openent.minibadge.model.Model;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ModelHelper {
+    private static final List<Class<?>> validJsonClasses = Arrays.asList(String.class, boolean.class, Boolean.class,
+            double.class, Double.class, float.class, Float.class, Integer.class, int.class, CharSequence.class,
+            JsonObject.class, JsonArray.class, Long.class, long.class);
+    private static final Logger log = LoggerFactory.getLogger(ModelHelper.class);
+
+    private ModelHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static <T extends Model<T>> List<T> toList(JsonArray results, Class<T> modelClass) {
+        return results.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .map(model -> toModel(model, modelClass))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+    }
+
+    public static JsonArray toJsonArray(List<? extends Model<?>> dataList) {
+        return new JsonArray(dataList.stream().map(Model::toJson).collect(Collectors.toList()));
+    }
+
+    /**
+     * Generic convert a list of {@link Object} to {@link JsonArray}.
+     * Classes that do not implement any {@link #validJsonClasses} class or model implementation will be ignored.
+     * Except {@link List} and {@link Enum}
+     *
+     * @param objects List of object
+     * @return {@link JsonArray}
+     */
+    private static JsonArray listToJsonArray(List<?> objects) {
+        JsonArray res = new JsonArray();
+        objects.stream()
+                .filter(Objects::nonNull)
+                .forEach(object -> {
+                    if (object instanceof Model) {
+                        res.add(((Model<?>) object).toJson());
+                    } else if (validJsonClasses.stream().anyMatch(aClass -> aClass.isInstance(object))) {
+                        res.add(object);
+                    } else if (object instanceof Enum) {
+                        res.add((Enum) object);
+                    } else if (object instanceof List) {
+                        res.add(listToJsonArray(((List<?>) object)));
+                    }
+                });
+        return res;
+    }
+
+    /**
+     * See {@link #sqlResultToModel(Promise, Class, String)}
+     */
+    public static <T extends Model<T>> Handler<Either<String, JsonArray>> sqlResultToModel(Promise<List<T>> promise,
+                                                                                           Class<T> modelClass) {
+        return sqlResultToModel(promise, modelClass, null);
+    }
+
+    /**
+     * Complete a promise from the result of a sql query, while converting this result into a list of model.
+     *
+     * @param promise      the promise we want to complete
+     * @param modelClass   the class of the model we want to convert
+     * @param errorMessage a message logged when the sql query fail
+     * @param <T>          the type of the model
+     */
+    public static <T extends Model<T>> Handler<Either<String, JsonArray>> sqlResultToModel(Promise<List<T>> promise,
+                                                                                           Class<T> modelClass,
+                                                                                           String errorMessage) {
+        return event -> {
+            if (event.isRight()) {
+                promise.complete(toList(event.right().getValue(), modelClass));
+                return;
+            }
+            log.error(String.format("%s %s", (errorMessage != null ? errorMessage : ""), event.left().getValue()));
+            promise.fail(errorMessage != null ? errorMessage : event.left().getValue());
+        };
+    }
+
+    /**
+     * See {@link #sqlUniqueResultToModel(Promise, Class, String)}
+     */
+    public static <T extends Model<T>> Handler<Either<String, JsonObject>> sqlUniqueResultToModel(Promise<Optional<T>> promise,
+                                                                                                  Class<T> modelClass) {
+        return sqlUniqueResultToModel(promise, modelClass, null);
+    }
+
+    /**
+     * Complete a promise from the result of a sql query, while converting this result into a model.
+     *
+     * @param promise      the promise we want to complete
+     * @param modelClass   the class of the model we want to convert
+     * @param errorMessage a message logged when the sql query fail
+     * @param <T>          the type of the model
+     */
+    public static <T extends Model<T>> Handler<Either<String, JsonObject>> sqlUniqueResultToModel(Promise<Optional<T>> promise,
+                                                                                                  Class<T> modelClass,
+                                                                                                  String errorMessage) {
+        return event -> {
+            if (event.isRight()) {
+                promise.complete(event.right().getValue().isEmpty() ? Optional.empty() : toModel(event.right().getValue(), modelClass));
+                return;
+            }
+            log.error(String.format("%s %s", (errorMessage != null ? errorMessage : ""), event.left().getValue()));
+            promise.fail(errorMessage != null ? errorMessage : event.left().getValue());
+        };
+    }
+
+    public static <T extends Model<T>> Optional<T> toModel(JsonObject model, Class<T> modelClass) {
+        try {
+            return Optional.of(modelClass.getConstructor(JsonObject.class).newInstance(model));
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                 InvocationTargetException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/fr/openent/minibadge/helper/ModelHelperTest.java
+++ b/src/test/java/fr/openent/minibadge/helper/ModelHelperTest.java
@@ -1,0 +1,183 @@
+package fr.openent.minibadge.helper;
+
+import fr.openent.minibadge.core.constants.Field;
+import fr.openent.minibadge.model.Model;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Constructor;
+import org.reflections.Reflections;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.reflections.scanners.Scanners.SubTypes;
+
+@RunWith(VertxUnitRunner.class)
+public class ModelHelperTest {
+    enum MyEnum {
+        VALUE1,
+        VALUE2,
+        VALUE3
+    }
+
+    static class MyClass {
+        public String id;
+    }
+    static class MyModel implements Model<MyModel> {
+        public String id;
+        public boolean isGood;
+        public MyOtherModel otherModel;
+        public MyClass myClass;
+        public List<Integer> typeIdList;
+        public List<MyOtherModel> otherModelList;
+        public List<MyClass> myClassList;
+        public List<List<JsonObject>> listList;
+        public MyEnum myEnum;
+        public List<MyEnum> myEnumList;
+        public MyEnum nullValue = null;
+
+        public MyModel() {
+        }
+
+        public MyModel(JsonObject jsonObject) {
+            this.id = jsonObject.getString(Field.ID);
+        }
+
+        @Override
+        public JsonObject toJson() {
+            return null;
+        }
+
+        @Override
+        public MyModel model(JsonObject model) {
+            return null;
+        }
+
+        @Override
+        public MyModel set(JsonObject model) {
+            return null;
+        }
+    }
+
+    static class MyOtherModel implements Model<MyOtherModel> {
+        public String myName;
+
+        public MyOtherModel() {
+        }
+
+        public MyOtherModel(JsonObject jsonObject) {
+            this.myName = jsonObject.getString("myName");
+        }
+
+        @Override
+        public JsonObject toJson() {
+            return null;
+        }
+
+        @Override
+        public MyOtherModel model(JsonObject model) {
+            return null;
+        }
+
+        @Override
+        public MyOtherModel set(JsonObject model) {
+            return null;
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(ModelHelperTest.class);
+
+    @Test
+    public void testSubClassModel(TestContext ctx) {
+        Reflections reflections = new Reflections("fr.openent.minibadge");
+        List<Class<?>> ignoredClassList = Arrays.asList(MyModel.class, MyOtherModel.class);
+
+        Set<Class<?>> subTypes =
+                reflections.get(SubTypes.of(Model.class).asClass());
+        List<Class<?>> invalidModel = subTypes.stream()
+                .filter(modelClass -> !ignoredClassList.contains(modelClass) && !modelClass.isInterface())
+                .filter(modelClass -> {
+                    Constructor<?> emptyConstructor = Arrays.stream(modelClass.getConstructors())
+                            .filter(constructor -> constructor.getParameterTypes().length == 1
+                                    && constructor.getParameterTypes()[0].equals(JsonObject.class))
+                            .findFirst()
+                            .orElse(null);
+                    return emptyConstructor == null;
+                }).collect(Collectors.toList());
+
+        invalidModel.forEach(modelClass -> {
+            String message = String.format("[Minibadge@%s::testSubClassModel]: The class %s must have public constructor with JsonObject parameter declared",
+                    this.getClass().getSimpleName(), modelClass.getSimpleName());
+            log.fatal(message);
+        });
+
+        ctx.assertTrue(invalidModel.isEmpty(), "One or more Model don't have public constructor with JsonObject parameter declared. Check log above.");
+    }
+
+    @Test
+    public void sqlUniqueResultToModelTest(TestContext ctx) {
+        Async async = ctx.async();
+        Promise<Optional<MyOtherModel>> promise = Promise.promise();
+
+        promise.future().onSuccess(myOtherModel -> {
+            ctx.assertTrue(myOtherModel.isPresent());
+            ctx.assertEquals(myOtherModel.get().myName, "test");
+            async.complete();
+        });
+
+        final Handler<Either<String, JsonObject>> handler = ModelHelper.sqlUniqueResultToModel(promise, MyOtherModel.class);
+        handler.handle(new Either.Right<>(new JsonObject("{\"myName\":\"test\"}")));
+
+        async.awaitSuccess(1000);
+    }
+
+    @Test
+    public void sqlResultToModelTest(TestContext ctx) {
+        Async async = ctx.async();
+        Promise<List<MyOtherModel>> promise = Promise.promise();
+
+        promise.future().onSuccess(myOtherModelList -> {
+            ctx.assertEquals(myOtherModelList.size(), 2);
+            ctx.assertEquals(myOtherModelList.get(0).myName, "test");
+            ctx.assertEquals(myOtherModelList.get(1).myName, "test2");
+            async.complete();
+        });
+
+        final Handler<Either<String, JsonArray>> handler = ModelHelper.sqlResultToModel(promise, MyOtherModel.class);
+        handler.handle(new Either.Right<>(new JsonArray("[{\"myName\":\"test\"}, {\"myName\":\"test2\"}]")));
+
+        async.awaitSuccess(1000);
+    }
+
+    @Test
+    public void toModelTest(TestContext ctx) {
+        Optional<MyModel> myModel = ModelHelper.toModel(new JsonObject().put(Field.ID, "3"), MyModel.class);
+        ctx.assertTrue(myModel.isPresent());
+        ctx.assertEquals(myModel.get().id, "3");
+
+        myModel = ModelHelper.toModel(new JsonObject(), MyModel.class);
+        ctx.assertTrue(myModel.isPresent());
+        ctx.assertNull(myModel.get().id);
+
+        //CastException
+        myModel = ModelHelper.toModel(new JsonObject().put(Field.ID, 3), MyModel.class);
+        ctx.assertFalse(myModel.isPresent());
+
+        //NPE
+        myModel = ModelHelper.toModel(null, MyModel.class);
+        ctx.assertFalse(myModel.isPresent());
+    }
+}


### PR DESCRIPTION
## Describe your changes
Afin de contourner contourner le problème de synchronisation sql en preprod, le flow d'assignation passe 

de:
insertion -> récupération de l'insertion précédente -> insertion de la donnée de statistique (assignation par structure)

à:
insertion + renvoie de la donnée insérée  -> insertion de la donnée de statistique (assignation par structure)

A savoir que désormais, dès que l'insertion de l'assignation est faite, on répond une 200 à l'utilisateur, indépendamment de l'insertion de la donnée de statistique (faite au préalable).

## Checklist tests
- Tester l'assgination d'un badge (à un ou plusieurs utilisateurs).
- l'assignation doit être faite
- on doit pouvoir retrouver la donnée insérer dans les données de comptage des statistiques.

## Issue ticket number and link
[Jira - MBA-137](https://jira.support-ent.fr/browse/MBA-137)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
