### PR TITLE
fix(badge-card): #MBA-155 make hover color only on info icon, and not the others.

### DIFF
--- a/src/main/resources/public/sass/global/_mixins.scss
+++ b/src/main/resources/public/sass/global/_mixins.scss
@@ -1,3 +1,7 @@
+$grey: #8c939e !default;
+$shadow: rgba(0, 0, 0, 0.26) !default;
+$white: #FFFFFF !default;
+
 $minibadge-blue-dark: #368daf;
 $minibadge-blue: #67add1;
 $minibadge-blue-light: #eff8fc;
@@ -16,6 +20,14 @@ $minibadge-shadow-light: transparentize($minibadge-shadow, 0.3);
 $minibadge-shadow-lighter: transparentize($minibadge-shadow, 0.7);
 
 $minibadge-font-secondary: 'Comfortaa', cursive;
+
+@mixin fonticon {
+  font-family: "generic-icons";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-image: none;
+  font-weight: normal!important;
+}
 
 @mixin mobile {
   @media (max-width: 768px) {

--- a/src/main/resources/public/sass/global/components/_badge.scss
+++ b/src/main/resources/public/sass/global/components/_badge.scss
@@ -23,10 +23,6 @@ minibadge-card-type {
         line-height: 24px;
         left: 0;
 
-        &:hover {
-          color: $minibadge-orange;
-        }
-
         @include mobile {
           padding: 5px;
         }

--- a/src/main/resources/public/sass/global/components/_card.scss
+++ b/src/main/resources/public/sass/global/components/_card.scss
@@ -21,6 +21,14 @@
     background: $minibadge-white;
     gap: 15px;
     @include paddingY(15px);
+
+    minibadge-card-type {
+      .minibadge-card {
+        &-body-icon:hover {
+          color: $minibadge-orange;
+        }
+      }
+    }
   }
 
   height: 232px;

--- a/src/main/resources/public/sass/index.scss
+++ b/src/main/resources/public/sass/index.scss
@@ -1,4 +1,2 @@
 /* ENTCORE CSS LIB */
-@import "./entcore-css-lib/scss/index.scss";
-
 @import "global/_minibadge.scss";


### PR DESCRIPTION
## Describe your changes
En ajoutant le changement de couleur au passage de la sourie sur l'icon information, celà a aussi changé les changements de couleurs pour les icones des autres cartes

## Checklist tests
Vérifier que sur les icones des autres cartes (page accueil par exemple), il n'y a plus de hover.
Vérifier que le hover est toujours là sur les cartes de la collection des types de badges.

## Issue ticket number and link
[Jira - MBA-155](https://jira.support-ent.fr/browse/MBA-155)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
