### PR TITLE
feat: #MBA-177 allow self-assignment of self-assignable badges 

### DIFF
--- a/src/main/java/fr/openent/minibadge/Minibadge.java
+++ b/src/main/java/fr/openent/minibadge/Minibadge.java
@@ -2,13 +2,9 @@ package fr.openent.minibadge;
 
 import fr.openent.minibadge.controller.*;
 import fr.openent.minibadge.model.Config;
+import fr.openent.minibadge.service.ServiceRegistry;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.EventBus;
 import org.entcore.common.http.BaseServer;
-import org.entcore.common.notification.TimelineHelper;
-import org.entcore.common.storage.Storage;
-import org.entcore.common.storage.StorageFactory;
 
 public class Minibadge extends BaseServer {
     public static final int PAGE_SIZE = 20;
@@ -17,21 +13,15 @@ public class Minibadge extends BaseServer {
 
     public static String dbSchema = MINIBADGE;
     public static Config minibadgeConfig;
-    public static Vertx minibadgeVertx;
-    public static Storage minibadgeStorage;
-    public static EventBus eventBus;
-    public static TimelineHelper timelineHelper;
 
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
+        ServiceRegistry.initServices();
+
         super.start(startPromise);
 
         dbSchema = config.getString("db-schema", MINIBADGE);
         minibadgeConfig = new Config(config);
-        minibadgeVertx = vertx;
-        minibadgeStorage = new StorageFactory(vertx, config).getStorage();
-        eventBus = getEventBus(vertx);
-        timelineHelper = new TimelineHelper(vertx, eventBus, config);
 
         addController(new MinibadgeController());
         addController(new SettingController());
@@ -45,5 +35,4 @@ public class Minibadge extends BaseServer {
 
         startPromise.tryComplete();
     }
-
 }

--- a/src/main/java/fr/openent/minibadge/controller/BadgeTypeController.java
+++ b/src/main/java/fr/openent/minibadge/controller/BadgeTypeController.java
@@ -72,7 +72,7 @@ public class BadgeTypeController extends ControllerHelper {
         String host = Renders.getHost(request);
         String language = I18n.acceptLanguage(request);
 
-        UserUtils.getUserInfos(eb, request, user -> badgeTypeService.getBadgeType(user.getStructures(), typeId, host, language)
+        UserUtils.getUserInfos(eb, request, user -> badgeTypeService.getBadgeType(user, typeId, host, language)
                 .onSuccess(badgeType -> renderJson(request, badgeType.toJson()))
                 .onFailure(err -> renderError(request, new JsonObject().put(Request.MESSAGE, err.getMessage()))));
     }

--- a/src/main/java/fr/openent/minibadge/core/constants/Field.java
+++ b/src/main/java/fr/openent/minibadge/core/constants/Field.java
@@ -68,6 +68,7 @@ public class Field {
     public static final String BADGEID = "badgeId";
     public static final String BADGE = "badge";
     public static final String MINIBADGECHART = "minibadgechart";
+    public static final String ISSELFASSIGNED = "isSelfAssigned";
 
     //BadgeAssignedStructure
     public static final String IS_STRUCTURE_ASSIGNER = "is_structure_assigner";

--- a/src/main/java/fr/openent/minibadge/core/constants/Field.java
+++ b/src/main/java/fr/openent/minibadge/core/constants/Field.java
@@ -105,6 +105,7 @@ public class Field {
     //Protagonist
     public static final String TYPEVALUE = "typeValue";
     public static final String ISSELFASSIGNABLE = "isSelfAssignable";
+    public static final String IS_SELF_ASSIGNABLE = "is_self_assignable";
     public static final String ASSIGNORTYPE = "assignorType";
     public static final String RECEIVERTYPE = "receiverType";
     public static final String SETTINGS = "settings";

--- a/src/main/java/fr/openent/minibadge/core/enums/SqlTable.java
+++ b/src/main/java/fr/openent/minibadge/core/enums/SqlTable.java
@@ -5,6 +5,8 @@ import fr.openent.minibadge.Minibadge;
 public enum SqlTable {
     REL_BADGE_CATEGORY_BADGE_TYPE("rel_badge_category_badge_type"),
     BADGE_TYPE("badge_type"),
+    BADGE_TYPE_SETTING("badge_type_setting"),
+    BADGE_CATEGORY("badge_category"),
     BADGE("badge"),
     BADGE_PUBLIC("badge_public"),
     BADGE_ASSIGNABLE("badge_assignable"),

--- a/src/main/java/fr/openent/minibadge/helper/SettingHelper.java
+++ b/src/main/java/fr/openent/minibadge/helper/SettingHelper.java
@@ -39,7 +39,7 @@ public class SettingHelper {
     }
 
     public static boolean isAuthorizedToAssign(User assignor, User receiver, TypeSetting typeSetting) {
-        // ✅ Refus si assignation à soi-même et non autorisée
+        // Refus si assignation à soi-même et non autorisée
         if (assignor.getUserId().equals(receiver.getUserId()) && !typeSetting.isSelfAssignable()) {
             return false;
         }

--- a/src/main/java/fr/openent/minibadge/helper/SettingHelper.java
+++ b/src/main/java/fr/openent/minibadge/helper/SettingHelper.java
@@ -39,12 +39,17 @@ public class SettingHelper {
     }
 
     public static boolean isAuthorizedToAssign(User assignor, User receiver, TypeSetting typeSetting) {
+        // ✅ Refus si assignation à soi-même et non autorisée
+        if (assignor.getUserId().equals(receiver.getUserId()) && !typeSetting.isSelfAssignable()) {
+            return false;
+        }
+
         return typeSetting.relations()
                 .stream()
-                .anyMatch((setting ->
+                .anyMatch(setting ->
                         isRelationAuthorized(assignor, setting.assignor())
                                 && isRelationAuthorized(receiver, setting.receiver())
-                ));
+                );
     }
 
     public static boolean isRelationAuthorized(User user, BadgeProtagonistSetting relation) {

--- a/src/main/java/fr/openent/minibadge/model/BadgeType.java
+++ b/src/main/java/fr/openent/minibadge/model/BadgeType.java
@@ -118,6 +118,10 @@ public class BadgeType implements Model<BadgeType> {
         this.mostAssigningUsers = mostAssigningUsers;
     }
 
+    public TypeSetting getSetting() {
+        return setting;
+    }
+
     public void setSetting(TypeSetting setting) {
         this.setting = setting;
     }

--- a/src/main/java/fr/openent/minibadge/model/BadgeType.java
+++ b/src/main/java/fr/openent/minibadge/model/BadgeType.java
@@ -26,6 +26,7 @@ public class BadgeType implements Model<BadgeType> {
     private List<User> mostAssigningUsers;
     private TypeSetting setting = new TypeSetting();
     private List<BadgeCategory> categories = new ArrayList<>();
+    private Boolean isSelfAssigned = false;
 
     public BadgeType() {
     }
@@ -130,6 +131,18 @@ public class BadgeType implements Model<BadgeType> {
         this.categories = categories;
     }
 
+    public List<BadgeCategory> categories() {
+        return categories;
+    }
+
+    public Boolean isSelfAssigned() {
+        return isSelfAssigned;
+    }
+
+    public void setSelfAssigned(Boolean selfAssigned) {
+        isSelfAssigned = selfAssigned;
+    }
+
     @Override
     public JsonObject toJson() {
         JsonObject badgeType = new JsonObject()
@@ -144,7 +157,8 @@ public class BadgeType implements Model<BadgeType> {
                 .put(COUNTASSIGNED, this.countAssigned)
                 .put(COUNTREFUSED, this.countRefused)
                 .put(SETTING, this.setting.toJson())
-                .put(CATEGORIES, this.categories.stream().map(BadgeCategory::toJson).collect(Collectors.toList()));
+                .put(CATEGORIES, this.categories.stream().map(BadgeCategory::toJson).collect(Collectors.toList()))
+                .put(ISSELFASSIGNED, this.isSelfAssigned);
         if (this.owner != null)
             badgeType.put(OWNER, this.owner.toJson());
 

--- a/src/main/java/fr/openent/minibadge/model/BadgeTypeSetting.java
+++ b/src/main/java/fr/openent/minibadge/model/BadgeTypeSetting.java
@@ -1,0 +1,90 @@
+package fr.openent.minibadge.model;
+
+import io.vertx.core.json.JsonObject;
+
+import static fr.openent.minibadge.core.constants.Field.*;
+
+public class BadgeTypeSetting implements Model<BadgeTypeSetting> {
+    private Long id;
+    private String structureId;
+    private String badgeTypeId;
+    private Boolean isSelfAssignable;
+    private String level;
+
+    public BadgeTypeSetting(JsonObject badgeTypeSetting) {
+        set(badgeTypeSetting);
+    }
+
+    @Override
+    public BadgeTypeSetting model(JsonObject badgeTypeSetting) {
+        return new BadgeTypeSetting(badgeTypeSetting);
+    }
+
+    @Override
+    public BadgeTypeSetting set(JsonObject badgeTypeSetting) {
+        this.id = badgeTypeSetting.getLong(ID, 0L);
+        this.structureId = badgeTypeSetting.getString(STRUCTURE_ID, "");
+        this.badgeTypeId = badgeTypeSetting.getString(BADGE_TYPE_ID, "");
+        this.isSelfAssignable = badgeTypeSetting.getBoolean(IS_SELF_ASSIGNABLE, false);
+        this.level = badgeTypeSetting.getString(LEVEL, "");
+        return this;
+    }
+
+    // Getters and Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public BadgeTypeSetting setId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getStructureId() {
+        return structureId;
+    }
+
+    public BadgeTypeSetting setStructureId(String structureId) {
+        this.structureId = structureId;
+        return this;
+    }
+
+    public String getBadgeTypeId() {
+        return badgeTypeId;
+    }
+
+    public BadgeTypeSetting setBadgeTypeId(String badgeTypeId) {
+        this.badgeTypeId = badgeTypeId;
+        return this;
+    }
+
+    public Boolean getIsSelfAssignable() {
+        return isSelfAssignable;
+    }
+
+    public BadgeTypeSetting setIsSelfAssignable(Boolean isSelfAssignable) {
+        this.isSelfAssignable = isSelfAssignable;
+        return this;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public BadgeTypeSetting setLevel(String level) {
+        this.level = level;
+        return this;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        json.put(ID, this.id);
+        json.put(STRUCTUREID, this.structureId);
+        json.put(BADGETYPEID, this.badgeTypeId);
+        json.put(ISSELFASSIGNABLE, this.isSelfAssignable);
+        json.put(LEVEL, this.level);
+        return json;
+    }
+}

--- a/src/main/java/fr/openent/minibadge/model/TypeSetting.java
+++ b/src/main/java/fr/openent/minibadge/model/TypeSetting.java
@@ -42,6 +42,11 @@ public class TypeSetting implements Model<TypeSetting> {
         return isSelfAssignable;
     }
 
+    public TypeSetting setSelfAssignable(boolean selfAssignable) {
+        isSelfAssignable = selfAssignable;
+        return this;
+    }
+
     public String structureId() {
         return structureId;
     }

--- a/src/main/java/fr/openent/minibadge/repository/BadgeTypeSettingRepository.java
+++ b/src/main/java/fr/openent/minibadge/repository/BadgeTypeSettingRepository.java
@@ -1,0 +1,15 @@
+package fr.openent.minibadge.repository;
+
+import fr.openent.minibadge.model.entity.BadgeTypeSetting;
+import io.vertx.core.Future;
+
+import java.util.Optional;
+
+public interface BadgeTypeSettingRepository {
+    /**
+     * Find a BadgeTypeSetting by its badgeTypeId.
+     * @param badgeTypeId the ID of the badge type
+     * @return a Future containing an Optional with the BadgeTypeSetting if found, or empty if not found
+     */
+    Future<Optional<BadgeTypeSetting>> findByBadgeTypeId(long badgeTypeId);
+}

--- a/src/main/java/fr/openent/minibadge/repository/BadgeTypeSettingRepository.java
+++ b/src/main/java/fr/openent/minibadge/repository/BadgeTypeSettingRepository.java
@@ -1,6 +1,6 @@
 package fr.openent.minibadge.repository;
 
-import fr.openent.minibadge.model.entity.BadgeTypeSetting;
+import fr.openent.minibadge.model.BadgeTypeSetting;
 import io.vertx.core.Future;
 
 import java.util.Optional;

--- a/src/main/java/fr/openent/minibadge/repository/impl/DefaultBadgeCategoryRepository.java
+++ b/src/main/java/fr/openent/minibadge/repository/impl/DefaultBadgeCategoryRepository.java
@@ -1,5 +1,6 @@
 package fr.openent.minibadge.repository.impl;
 
+import fr.openent.minibadge.core.enums.SqlTable;
 import fr.openent.minibadge.helper.LoggerHelper;
 import fr.openent.minibadge.helper.ModelHelper;
 import fr.openent.minibadge.model.BadgeCategory;
@@ -24,8 +25,8 @@ public class DefaultBadgeCategoryRepository implements BadgeCategoryRepository {
 
         String query =
             "SELECT bc.id, bc.name, bc.slug, bc.icon_name, bc.created_at, bc.updated_at " +
-            "FROM minibadge.badge_category bc " +
-            "INNER JOIN minibadge.rel_badge_category_badge_type rbcbt " +
+            "FROM " + SqlTable.BADGE_CATEGORY.getName() +"  bc " +
+            "INNER JOIN " + SqlTable.REL_BADGE_CATEGORY_BADGE_TYPE.getName() +" rbcbt " +
                 "ON bc.id = rbcbt.badge_category_id " +
             "WHERE rbcbt.badge_type_id = ?";
 
@@ -42,7 +43,7 @@ public class DefaultBadgeCategoryRepository implements BadgeCategoryRepository {
     public Future<List<BadgeCategory>> findAll() {
         Promise <List<BadgeCategory>> promise = Promise.promise();
 
-        String query = "SELECT * FROM minibadge.badge_category";
+        String query = "SELECT * FROM " + SqlTable.BADGE_CATEGORY.getName();
 
         String errorMessage = "Error while getting all badge categories";
         String completeLog = LoggerHelper.getCompleteLog(this, "findAll", errorMessage);

--- a/src/main/java/fr/openent/minibadge/repository/impl/DefaultBadgeTypeSettingRepository.java
+++ b/src/main/java/fr/openent/minibadge/repository/impl/DefaultBadgeTypeSettingRepository.java
@@ -3,7 +3,7 @@ package fr.openent.minibadge.repository.impl;
 import fr.openent.minibadge.core.enums.SqlTable;
 import fr.openent.minibadge.helper.LoggerHelper;
 import fr.openent.minibadge.helper.ModelHelper;
-import fr.openent.minibadge.model.entity.BadgeTypeSetting;
+import fr.openent.minibadge.model.BadgeTypeSetting;
 import fr.openent.minibadge.repository.BadgeTypeSettingRepository;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;

--- a/src/main/java/fr/openent/minibadge/repository/impl/DefaultBadgeTypeSettingRepository.java
+++ b/src/main/java/fr/openent/minibadge/repository/impl/DefaultBadgeTypeSettingRepository.java
@@ -1,0 +1,34 @@
+package fr.openent.minibadge.repository.impl;
+
+import fr.openent.minibadge.core.enums.SqlTable;
+import fr.openent.minibadge.helper.LoggerHelper;
+import fr.openent.minibadge.helper.ModelHelper;
+import fr.openent.minibadge.model.entity.BadgeTypeSetting;
+import fr.openent.minibadge.repository.BadgeTypeSettingRepository;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import org.entcore.common.sql.Sql;
+import org.entcore.common.sql.SqlResult;
+
+import java.util.Optional;
+
+public class DefaultBadgeTypeSettingRepository implements BadgeTypeSettingRepository {
+
+    private final Sql sql = Sql.getInstance();
+
+    @Override
+    public Future<Optional<BadgeTypeSetting>> findByBadgeTypeId(long badgeTypeId) {
+        Promise<Optional<BadgeTypeSetting>> promise = Promise.promise();
+
+        String query = "SELECT * FROM " + SqlTable.BADGE_TYPE_SETTING.getName() + " WHERE badge_type_id = ?";
+
+        JsonArray params = new JsonArray().add(badgeTypeId);
+
+        String errorMessage = "Error while fetching badge type setting with badgeTypeId: " + badgeTypeId;
+        String completeLog = LoggerHelper.getCompleteLog(this, "findByBadgeTypeId", errorMessage);
+        sql.prepared(query, params, SqlResult.validUniqueResultHandler(ModelHelper.sqlUniqueResultToModel(promise, BadgeTypeSetting.class, completeLog)));
+
+        return promise.future();
+    }
+}

--- a/src/main/java/fr/openent/minibadge/repository/impl/RepositoryFactory.java
+++ b/src/main/java/fr/openent/minibadge/repository/impl/RepositoryFactory.java
@@ -1,15 +1,18 @@
 package fr.openent.minibadge.repository.impl;
 
 import fr.openent.minibadge.repository.BadgeCategoryRepository;
+import fr.openent.minibadge.repository.BadgeTypeSettingRepository;
 
 public final class RepositoryFactory {
 
     private static final RepositoryFactory instance = new RepositoryFactory();
 
     private final BadgeCategoryRepository badgeCategoryRepository;
+    private final BadgeTypeSettingRepository badgeTypeSettingRepository;
 
     private RepositoryFactory() {
         this.badgeCategoryRepository = new DefaultBadgeCategoryRepository();
+        this.badgeTypeSettingRepository = new DefaultBadgeTypeSettingRepository();
     }
 
     public static RepositoryFactory getInstance() {
@@ -18,5 +21,9 @@ public final class RepositoryFactory {
 
     public BadgeCategoryRepository badgeCategoryRepository() {
         return badgeCategoryRepository;
+    }
+
+    public BadgeTypeSettingRepository badgeTypeSettingRepository() {
+        return badgeTypeSettingRepository;
     }
 }

--- a/src/main/java/fr/openent/minibadge/service/BadgeAssignedService.java
+++ b/src/main/java/fr/openent/minibadge/service/BadgeAssignedService.java
@@ -62,4 +62,12 @@ public interface BadgeAssignedService {
      * @return return future containing assigners count
      */
     Future<Integer> countTotalAssigners(long typeId, UserInfos badgeOwner);
+
+    /**
+     * Check if the user has assigned himself a badge of this type
+     * @param userInfos user information
+     * @param typeId    type identifier
+     * @return return future containing boolean
+     */
+    Future<Boolean> isSelfAssigned(UserInfos userInfos, long typeId);
 }

--- a/src/main/java/fr/openent/minibadge/service/BadgeTypeService.java
+++ b/src/main/java/fr/openent/minibadge/service/BadgeTypeService.java
@@ -2,6 +2,7 @@ package fr.openent.minibadge.service;
 
 import fr.openent.minibadge.model.BadgeType;
 import io.vertx.core.Future;
+import org.entcore.common.user.UserInfos;
 
 import java.util.List;
 
@@ -22,11 +23,11 @@ public interface BadgeTypeService {
     /**
      * Get badge type
      *
-     * @param structureIds Structure identifiers
+     * @param userInfos    User information
      * @param typeId       Type identifier
      * @param host         Host
      * @param language     accepted language
      * @return return list of badge type (model)
      */
-    Future<BadgeType> getBadgeType(List<String> structureIds, long typeId, String host, String language);
+    Future<BadgeType> getBadgeType(UserInfos userInfos, long typeId, String host, String language);
 }

--- a/src/main/java/fr/openent/minibadge/service/BadgeTypeSettingService.java
+++ b/src/main/java/fr/openent/minibadge/service/BadgeTypeSettingService.java
@@ -1,0 +1,15 @@
+package fr.openent.minibadge.service;
+
+import fr.openent.minibadge.model.entity.BadgeTypeSetting;
+import io.vertx.core.Future;
+
+import java.util.Optional;
+
+public interface BadgeTypeSettingService {
+    /**
+     * Check if a badge type is self-assignable.
+     * @param badgeTypeId the ID of the badge type
+     * @return a Future that will complete with true if the badge type is self-assignable, false otherwise
+     */
+    Future<Boolean> isBadgeTypeSelfAssignable(Long badgeTypeId);
+}

--- a/src/main/java/fr/openent/minibadge/service/BadgeTypeSettingService.java
+++ b/src/main/java/fr/openent/minibadge/service/BadgeTypeSettingService.java
@@ -1,9 +1,6 @@
 package fr.openent.minibadge.service;
 
-import fr.openent.minibadge.model.entity.BadgeTypeSetting;
 import io.vertx.core.Future;
-
-import java.util.Optional;
 
 public interface BadgeTypeSettingService {
     /**

--- a/src/main/java/fr/openent/minibadge/service/ServiceRegistry.java
+++ b/src/main/java/fr/openent/minibadge/service/ServiceRegistry.java
@@ -10,10 +10,11 @@ public final class ServiceRegistry {
     private static final Map<Class<?>, Object> SERVICES = new ConcurrentHashMap<>();
 
     static {
-        // Instanciation unique des singletons dans la map
+        // Instanciation unique des singletons dans la map dans l'ordre des dépendances
         SERVICES.put(UserService.class, DefaultUserService.getInstance());
         SERVICES.put(SettingService.class, DefaultSettingService.getInstance());
         SERVICES.put(BadgeCategoryService.class, DefaultBadgeCategoryService.getInstance());
+        SERVICES.put(BadgeTypeSettingService.class, DefaultBadgeTypeSettingService.getInstance());
         SERVICES.put(BadgeTypeService.class, DefaultBadgeTypeService.getInstance());
         SERVICES.put(BadgeService.class, DefaultBadgeService.getInstance());
         SERVICES.put(BadgeAssignedStructureService.class, DefaultBadgeAssignedStructureService.getInstance());

--- a/src/main/java/fr/openent/minibadge/service/ServiceRegistry.java
+++ b/src/main/java/fr/openent/minibadge/service/ServiceRegistry.java
@@ -19,12 +19,12 @@ public final class ServiceRegistry {
 
         SERVICES.put(UserService.class, DefaultUserService.getInstance());
         SERVICES.put(SettingService.class, DefaultSettingService.getInstance());
-        SERVICES.put(BadgeCategoryService.class, DefaultBadgeCategoryService.getInstance());
-        SERVICES.put(BadgeTypeSettingService.class, DefaultBadgeTypeSettingService.getInstance());
-        SERVICES.put(BadgeTypeService.class, DefaultBadgeTypeService.getInstance());
         SERVICES.put(BadgeService.class, DefaultBadgeService.getInstance());
         SERVICES.put(BadgeAssignedStructureService.class, DefaultBadgeAssignedStructureService.getInstance());
         SERVICES.put(BadgeAssignedService.class, DefaultBadgeAssignedService.getInstance());
+        SERVICES.put(BadgeCategoryService.class, DefaultBadgeCategoryService.getInstance());
+        SERVICES.put(BadgeTypeSettingService.class, DefaultBadgeTypeSettingService.getInstance());
+        SERVICES.put(BadgeTypeService.class, DefaultBadgeTypeService.getInstance());
         SERVICES.put(StructureService.class, DefaultStructureService.getInstance());
         SERVICES.put(StatisticService.class, DefaultStatisticService.getInstance());
         SERVICES.put(NotifyService.class, DefaultNotifyService.getInstance());

--- a/src/main/java/fr/openent/minibadge/service/ServiceRegistry.java
+++ b/src/main/java/fr/openent/minibadge/service/ServiceRegistry.java
@@ -9,8 +9,14 @@ public final class ServiceRegistry {
 
     private static final Map<Class<?>, Object> SERVICES = new ConcurrentHashMap<>();
 
-    static {
-        // Instanciation unique des singletons dans la map dans l'ordre des dépendances
+    private static boolean initialized = false;
+
+    /**
+     * Initialise tous les services dans l'ordre des dépendances.
+     */
+    public static synchronized void initServices() {
+        if (initialized) return;
+
         SERVICES.put(UserService.class, DefaultUserService.getInstance());
         SERVICES.put(SettingService.class, DefaultSettingService.getInstance());
         SERVICES.put(BadgeCategoryService.class, DefaultBadgeCategoryService.getInstance());
@@ -22,7 +28,10 @@ public final class ServiceRegistry {
         SERVICES.put(StructureService.class, DefaultStructureService.getInstance());
         SERVICES.put(StatisticService.class, DefaultStatisticService.getInstance());
         SERVICES.put(NotifyService.class, DefaultNotifyService.getInstance());
+
+        initialized = true;
     }
+
 
     // Private constructor to prevent instantiation
     private ServiceRegistry() {}

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeService.java
@@ -1,6 +1,5 @@
 package fr.openent.minibadge.service.impl;
 
-import fr.openent.minibadge.Minibadge;
 import fr.openent.minibadge.core.constants.Field;
 import fr.openent.minibadge.core.enums.SqlTable;
 import fr.openent.minibadge.helper.LoggerHelper;
@@ -15,10 +14,11 @@ import fr.openent.minibadge.service.BadgeTypeService;
 import fr.openent.minibadge.service.BadgeTypeSettingService;
 import fr.openent.minibadge.service.ServiceRegistry;
 import fr.wseduc.webutils.I18n;
+import fr.wseduc.webutils.Server;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.sql.Sql;
@@ -38,7 +38,6 @@ public class DefaultBadgeTypeService implements BadgeTypeService {
     }
 
     private final Sql sql = Sql.getInstance();
-    private final EventBus eb = Minibadge.eventBus;
     private final BadgeCategoryService badgeCategoryService = ServiceRegistry.getService(BadgeCategoryService.class);
     private final BadgeTypeSettingService badgeTypeSettingService = ServiceRegistry.getService(BadgeTypeSettingService.class);
 
@@ -167,7 +166,7 @@ public class DefaultBadgeTypeService implements BadgeTypeService {
 
         if (badgeType.ownerId() != null) {
             Promise<User> promise = Promise.promise();
-            UserUtils.getUserInfos(eb, badgeType.ownerId(), user -> promise.complete((User) user));
+            UserUtils.getUserInfos(Server.getEventBus(Vertx.currentContext().owner()), badgeType.ownerId(), user -> promise.complete((User) user));
             return promise.future();
         }
 

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeService.java
@@ -12,6 +12,7 @@ import fr.openent.minibadge.model.User;
 import fr.openent.minibadge.model.BadgeCategory;
 import fr.openent.minibadge.service.BadgeCategoryService;
 import fr.openent.minibadge.service.BadgeTypeService;
+import fr.openent.minibadge.service.BadgeTypeSettingService;
 import fr.openent.minibadge.service.ServiceRegistry;
 import fr.wseduc.webutils.I18n;
 import io.vertx.core.CompositeFuture;
@@ -39,6 +40,7 @@ public class DefaultBadgeTypeService implements BadgeTypeService {
     private final Sql sql = Sql.getInstance();
     private final EventBus eb = Minibadge.eventBus;
     private final BadgeCategoryService badgeCategoryService = ServiceRegistry.getService(BadgeCategoryService.class);
+    private final BadgeTypeSettingService badgeTypeSettingService = ServiceRegistry.getService(BadgeTypeSettingService.class);
 
     @Override
     public Future<List<BadgeType>> getBadgeTypes(List<String> structureIds, String query, int limit, Integer offset, Long badgeCategoryId) {
@@ -47,14 +49,16 @@ public class DefaultBadgeTypeService implements BadgeTypeService {
         getBadgesTypesRequest(structureIds, query, limit, offset, badgeCategoryId)
                 .onSuccess(badgeTypesArray -> {
                     List<BadgeType> badgeTypes = new BadgeType().toList(badgeTypesArray);
-                    badgeTypes.forEach(badgeType -> badgeType.setSetting(SettingHelper.getDefaultTypeSetting()));
 
                     List<Future> categoryFutures = new ArrayList<>();
 
                     for (BadgeType badgeType : badgeTypes) {
-                        Future<List<BadgeCategory>> future = badgeCategoryService.getBadgeCategoriesByBadgeTypeId(badgeType.id())
+                        Future<List<BadgeCategory>> categoryFuture = badgeCategoryService.getBadgeCategoriesByBadgeTypeId(badgeType.id())
                                 .onSuccess(badgeType::setCategories);
-                        categoryFutures.add(future);
+                        Future<Boolean> settingFuture = badgeTypeSettingService.isBadgeTypeSelfAssignable(badgeType.id())
+                                .onSuccess(isSelfAssignable -> badgeType.setSetting(SettingHelper.getDefaultTypeSetting().setSelfAssignable(isSelfAssignable)));
+                        categoryFutures.add(categoryFuture);
+                        categoryFutures.add(settingFuture);
                     }
 
                     CompositeFuture.all(categoryFutures)
@@ -125,11 +129,14 @@ public class DefaultBadgeTypeService implements BadgeTypeService {
                 })
                 .compose(user -> {
                     badgeType.setOwner(user);
-                    badgeType.setSetting(SettingHelper.getDefaultTypeSetting());
                     return badgeCategoryService.getBadgeCategoriesByBadgeTypeId(badgeType.id());
                 })
-                .onSuccess(badgeCategories -> {
+                .compose(badgeCategories -> {
                     badgeType.setCategories(badgeCategories);
+                    return badgeTypeSettingService.isBadgeTypeSelfAssignable(badgeType.id());
+                })
+                .onSuccess(isSelfAssignable -> {
+                    badgeType.setSetting(SettingHelper.getDefaultTypeSetting().setSelfAssignable(isSelfAssignable));
                     promise.complete(badgeType);
                 })
                 .onFailure(promise::fail);

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeSettingService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeSettingService.java
@@ -1,13 +1,11 @@
 package fr.openent.minibadge.service.impl;
 
-import fr.openent.minibadge.model.entity.BadgeTypeSetting;
 import fr.openent.minibadge.repository.BadgeTypeSettingRepository;
 import fr.openent.minibadge.service.AbstractService;
 import fr.openent.minibadge.service.BadgeTypeSettingService;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 
-import java.util.Optional;
 
 public class DefaultBadgeTypeSettingService extends AbstractService implements BadgeTypeSettingService {
 

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeSettingService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeSettingService.java
@@ -1,0 +1,40 @@
+package fr.openent.minibadge.service.impl;
+
+import fr.openent.minibadge.model.entity.BadgeTypeSetting;
+import fr.openent.minibadge.repository.BadgeTypeSettingRepository;
+import fr.openent.minibadge.service.AbstractService;
+import fr.openent.minibadge.service.BadgeTypeSettingService;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+import java.util.Optional;
+
+public class DefaultBadgeTypeSettingService extends AbstractService implements BadgeTypeSettingService {
+
+    private static final DefaultBadgeTypeSettingService instance = new DefaultBadgeTypeSettingService();
+
+    private DefaultBadgeTypeSettingService() {}
+
+    public static DefaultBadgeTypeSettingService getInstance() {
+        return instance;
+    }
+
+    private final BadgeTypeSettingRepository badgeTypeSettingRepository = repositories.badgeTypeSettingRepository();
+
+    @Override
+    public Future<Boolean> isBadgeTypeSelfAssignable(Long badgeTypeId) {
+        Promise<Boolean> promise = Promise.promise();
+
+        badgeTypeSettingRepository.findByBadgeTypeId(badgeTypeId)
+                .onSuccess(optionalSetting -> {
+                    if (optionalSetting.isPresent()) {
+                        promise.complete(optionalSetting.get().getIsSelfAssignable());
+                    } else {
+                        promise.complete(false); // Default to false if no setting found
+                    }
+                })
+                .onFailure(promise::fail);
+
+        return promise.future();
+    }
+}

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeSettingService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultBadgeTypeSettingService.java
@@ -1,5 +1,6 @@
 package fr.openent.minibadge.service.impl;
 
+import fr.openent.minibadge.helper.LoggerHelper;
 import fr.openent.minibadge.repository.BadgeTypeSettingRepository;
 import fr.openent.minibadge.service.AbstractService;
 import fr.openent.minibadge.service.BadgeTypeSettingService;
@@ -31,7 +32,11 @@ public class DefaultBadgeTypeSettingService extends AbstractService implements B
                         promise.complete(false); // Default to false if no setting found
                     }
                 })
-                .onFailure(promise::fail);
+                .onFailure(err -> {
+                    String errorMessage = "Error retrieving badge type setting for badgeTypeId: " + badgeTypeId;
+                    LoggerHelper.logError(this, "isBadgeTypeSelfAssignable", errorMessage, err.getMessage());
+                    promise.fail(err);
+                });
 
         return promise.future();
     }

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultNotifyService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultNotifyService.java
@@ -16,6 +16,7 @@ import org.entcore.common.notification.TimelineHelper;
 import org.entcore.common.user.UserInfos;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class DefaultNotifyService implements NotifyService {
 
@@ -31,6 +32,10 @@ public class DefaultNotifyService implements NotifyService {
     public void notifyBadgeAssigned(HttpServerRequest request, UserInfos assigner, List<String> ownerIds, long typeId) {
         String host = Renders.getHost(request);
         String language = I18n.acceptLanguage(request);
+
+        List<String> ownerIdsWithoutAssigner = ownerIds.stream().filter(id -> !id.equals(assigner.getUserId())).collect(Collectors.toList());
+
+        if (ownerIdsWithoutAssigner.isEmpty()) return;
 
         badgeTypeService.getBadgeType(assigner.getStructures(), typeId, host, language)
                 .onSuccess(badgeType -> {
@@ -48,7 +53,7 @@ public class DefaultNotifyService implements NotifyService {
                             Server.getEventBus(Vertx.currentContext().owner()),
                             Minibadge.minibadgeConfig.toJson());
                     timelineHelper.notifyTimeline(request, String.format("%s.%s", Minibadge.MINIBADGE, Notify.NEW_BADGE_ASSIGNED),
-                            assigner, ownerIds, params);
+                            assigner, ownerIdsWithoutAssigner, params);
                 });
     }
 }

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultNotifyService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultNotifyService.java
@@ -37,7 +37,7 @@ public class DefaultNotifyService implements NotifyService {
 
         if (ownerIdsWithoutAssigner.isEmpty()) return;
 
-        badgeTypeService.getBadgeType(assigner.getStructures(), typeId, host, language)
+        badgeTypeService.getBadgeType(assigner, typeId, host, language)
                 .onSuccess(badgeType -> {
                     String uri = String.format("/minibadge#/badge-types/%s", badgeType.id());
                     JsonObject params = new JsonObject()

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultNotifyService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultNotifyService.java
@@ -7,7 +7,9 @@ import fr.openent.minibadge.service.BadgeTypeService;
 import fr.openent.minibadge.service.NotifyService;
 import fr.openent.minibadge.service.ServiceRegistry;
 import fr.wseduc.webutils.I18n;
+import fr.wseduc.webutils.Server;
 import fr.wseduc.webutils.http.Renders;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.notification.TimelineHelper;
@@ -23,7 +25,6 @@ public class DefaultNotifyService implements NotifyService {
         return instance;
     }
 
-    private final TimelineHelper timelineHelper = Minibadge.timelineHelper;
     private final BadgeTypeService badgeTypeService = ServiceRegistry.getService(BadgeTypeService.class);
 
     @Override
@@ -42,6 +43,10 @@ public class DefaultNotifyService implements NotifyService {
                             .put(Field.PUSHNOTIF, new JsonObject()
                                     .put(Field.TITLE, "minibadge.new.badge.assigned.title").put(Field.BODY, ""));
 
+                    TimelineHelper timelineHelper = new TimelineHelper(
+                            Vertx.currentContext().owner(),
+                            Server.getEventBus(Vertx.currentContext().owner()),
+                            Minibadge.minibadgeConfig.toJson());
                     timelineHelper.notifyTimeline(request, String.format("%s.%s", Minibadge.MINIBADGE, Notify.NEW_BADGE_ASSIGNED),
                             assigner, ownerIds, params);
                 });

--- a/src/main/java/fr/openent/minibadge/service/impl/DefaultUserService.java
+++ b/src/main/java/fr/openent/minibadge/service/impl/DefaultUserService.java
@@ -1,6 +1,5 @@
 package fr.openent.minibadge.service.impl;
 
-import fr.openent.minibadge.Minibadge;
 import fr.openent.minibadge.core.constants.Rights;
 import fr.openent.minibadge.core.enums.SqlTable;
 import fr.openent.minibadge.helper.Neo4jHelper;
@@ -9,9 +8,10 @@ import fr.openent.minibadge.helper.SettingHelper;
 import fr.openent.minibadge.model.User;
 import fr.openent.minibadge.service.UserService;
 import fr.wseduc.webutils.I18n;
+import fr.wseduc.webutils.Server;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -35,7 +35,6 @@ public class DefaultUserService implements UserService {
         return instance;
     }
 
-    private final EventBus eb = Minibadge.eventBus;
     private final Sql sql = Sql.getInstance();
     private final Neo4j neo = Neo4j.getInstance();
 
@@ -72,7 +71,7 @@ public class DefaultUserService implements UserService {
                         Neo4jHelper.usersNodeHasRight(Rights.FULLNAME_RECEIVE, params)),
                 MINIBADGECHART);
 
-        UserUtils.findVisibleUsers(eb, request, false, true,
+        UserUtils.findVisibleUsers(Server.getEventBus(Vertx.currentContext().owner()), request, false, true,
                 String.format(" %s %s ", (query != null && !query.isEmpty()) ? "AND" : "", preFilter),
                 customReturn, params, promise::complete);
 

--- a/src/main/resources/sql/020-insert-badge-type-setting.sql
+++ b/src/main/resources/sql/020-insert-badge-type-setting.sql
@@ -1,0 +1,16 @@
+INSERT INTO minibadge.badge_type_setting (structure_id, badge_type_id, is_self_assignable, level)
+VALUES
+    (NULL, 2,  TRUE, NULL),
+    (NULL, 3,  TRUE, NULL),
+    (NULL, 4,  TRUE, NULL),
+    (NULL, 7,  TRUE, NULL),
+    (NULL, 8,  TRUE, NULL),
+    (NULL, 9,  TRUE, NULL),
+    (NULL, 10, TRUE, NULL),
+    (NULL, 11, TRUE, NULL),
+    (NULL, 13, TRUE, NULL),
+    (NULL, 22, TRUE, NULL),
+    (NULL, 23, TRUE, NULL),
+    (NULL, 24, TRUE, NULL),
+    (NULL, 26, TRUE, NULL)
+    ON CONFLICT (structure_id, badge_type_id) DO NOTHING;


### PR DESCRIPTION
## Describe your changes

This PR implements support for **self-assignment of badges** when the badge type is marked as _self-assignable_.

An assignment is now authorized if:
- The assignor and receiver are the same user, **and**
- The badge type has `isSelfAssignable = true`.

### Main changes

- Updated `isAuthorizedToAssign` logic to allow self-assignment only when explicitly allowed.
- Prevented self-assignment when the flag is `false`.
- (Optional) Adjusted notification logic to avoid notifying the assignor when assigning to themselves.

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
